### PR TITLE
Recover lost files required for cross-compilation wallet using Dash v…

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -1,0 +1,161 @@
+.NOTPARALLEL :
+
+SOURCES_PATH ?= $(BASEDIR)/sources
+BASE_CACHE ?= $(BASEDIR)/built
+SDK_PATH ?= $(BASEDIR)/SDKs
+NO_QT ?=
+NO_WALLET ?=
+NO_UPNP ?=
+FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources
+
+BUILD = $(shell ./config.guess)
+HOST ?= $(BUILD)
+PATCHES_PATH = $(BASEDIR)/patches
+BASEDIR = $(CURDIR)
+HASH_LENGTH:=11
+DOWNLOAD_CONNECT_TIMEOUT:=10
+DOWNLOAD_RETRIES:=3
+
+host:=$(BUILD)
+ifneq ($(HOST),)
+host:=$(HOST)
+host_toolchain:=$(HOST)-
+endif
+
+ifneq ($(DEBUG),)
+release_type=debug
+else
+release_type=release
+endif
+
+base_build_dir=$(BASEDIR)/work/build
+base_staging_dir=$(BASEDIR)/work/staging
+base_download_dir=$(BASEDIR)/work/download
+canonical_host:=$(shell ./config.sub $(HOST))
+build:=$(shell ./config.sub $(BUILD))
+
+build_arch =$(firstword $(subst -, ,$(build)))
+build_vendor=$(word 2,$(subst -, ,$(build)))
+full_build_os:=$(subst $(build_arch)-$(build_vendor)-,,$(build))
+build_os:=$(findstring linux,$(full_build_os))
+build_os+=$(findstring darwin,$(full_build_os))
+build_os:=$(strip $(build_os))
+ifeq ($(build_os),)
+build_os=$(full_build_os)
+endif
+
+host_arch=$(firstword $(subst -, ,$(canonical_host)))
+host_vendor=$(word 2,$(subst -, ,$(canonical_host)))
+full_host_os:=$(subst $(host_arch)-$(host_vendor)-,,$(canonical_host))
+host_os:=$(findstring linux,$(full_host_os))
+host_os+=$(findstring darwin,$(full_host_os))
+host_os+=$(findstring mingw32,$(full_host_os))
+host_os:=$(strip $(host_os))
+ifeq ($(host_os),)
+host_os=$(full_host_os)
+endif
+
+$(host_arch)_$(host_os)_prefix=$(BASEDIR)/$(host)
+$(host_arch)_$(host_os)_host=$(host)
+host_prefix=$($(host_arch)_$(host_os)_prefix)
+build_prefix=$(host_prefix)/native
+build_host=$(build)
+
+AT_$(V):=
+AT_:=@
+AT:=$(AT_$(V))
+
+all: install
+
+include hosts/$(host_os).mk
+include hosts/default.mk
+include builders/$(build_os).mk
+include builders/default.mk
+include packages/packages.mk
+
+qt_packages_$(NO_QT) = $(qt_packages) $(qt_$(host_os)_packages)
+qt_native_packages_$(NO_QT) = $(qt_native_packages)
+wallet_packages_$(NO_WALLET) = $(wallet_packages)
+upnp_packages_$(NO_UPNP) = $(upnp_packages)
+
+packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(qt_packages_) $(wallet_packages_) $(upnp_packages_)
+native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_native_packages) $(qt_native_packages_)
+all_packages = $(packages) $(native_packages)
+
+meta_depends = Makefile funcs.mk builders/default.mk hosts/default.mk hosts/$(host_os).mk builders/$(build_os).mk
+
+$(host_arch)_$(host_os)_native_toolchain?=$($(host_os)_native_toolchain)
+
+include funcs.mk
+
+toolchain_path=$($($(host_arch)_$(host_os)_native_toolchain)_prefixbin)
+final_build_id_long+=$(shell $(build_SHA256SUM) config.site.in)
+final_build_id+=$(shell echo -n $(final_build_id_long) | $(build_SHA256SUM) | cut -c-$(HASH_LENGTH))
+$(host_prefix)/.stamp_$(final_build_id): $(native_packages) $(packages)
+	$(AT)rm -rf $(@D)
+	$(AT)mkdir -p $(@D)
+	$(AT)echo copying packages: $^
+	$(AT)echo to: $(@D)
+	$(AT)cd $(@D); $(foreach package,$^, tar xf $($(package)_cached); )
+	$(AT)touch $@
+
+$(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_build_id)
+	$(AT)@mkdir -p $(@D)
+	$(AT)sed -e 's|@HOST@|$(host)|' \
+            -e 's|@CC@|$(toolchain_path)$(host_CC)|' \
+            -e 's|@CXX@|$(toolchain_path)$(host_CXX)|' \
+            -e 's|@AR@|$(toolchain_path)$(host_AR)|' \
+            -e 's|@RANLIB@|$(toolchain_path)$(host_RANLIB)|' \
+            -e 's|@NM@|$(toolchain_path)$(host_NM)|' \
+            -e 's|@STRIP@|$(toolchain_path)$(host_STRIP)|' \
+            -e 's|@build_os@|$(build_os)|' \
+            -e 's|@host_os@|$(host_os)|' \
+            -e 's|@CFLAGS@|$(strip $(host_CFLAGS) $(host_$(release_type)_CFLAGS))|' \
+            -e 's|@CXXFLAGS@|$(strip $(host_CXXFLAGS) $(host_$(release_type)_CXXFLAGS))|' \
+            -e 's|@CPPFLAGS@|$(strip $(host_CPPFLAGS) $(host_$(release_type)_CPPFLAGS))|' \
+            -e 's|@LDFLAGS@|$(strip $(host_LDFLAGS) $(host_$(release_type)_LDFLAGS))|' \
+            -e 's|@no_qt@|$(NO_QT)|' \
+            -e 's|@no_wallet@|$(NO_WALLET)|' \
+            -e 's|@no_upnp@|$(NO_UPNP)|' \
+            -e 's|@debug@|$(DEBUG)|' \
+            $< > $@
+	$(AT)touch $@
+
+
+define check_or_remove_cached
+  mkdir -p $(BASE_CACHE)/$(host)/$(package) && cd $(BASE_CACHE)/$(host)/$(package); \
+  $(build_SHA256SUM) -c $($(package)_cached_checksum) >/dev/null 2>/dev/null || \
+  ( rm -f $($(package)_cached_checksum); \
+    if test -f "$($(package)_cached)"; then echo "Checksum mismatch for $(package). Forcing rebuild.."; rm -f $($(package)_cached_checksum) $($(package)_cached); fi )
+endef
+
+define check_or_remove_sources
+  mkdir -p $($(package)_source_dir); cd $($(package)_source_dir); \
+  $(build_SHA256SUM) -c $($(package)_fetched) >/dev/null 2>/dev/null || \
+    ( if test -f $($(package)_all_sources); then echo "Checksum missing or mismatched for $(package) source. Forcing re-download."; fi; \
+      rm -f $($(package)_all_sources) $($(1)_fetched))
+endef
+
+check-packages:
+	@$(foreach package,$(all_packages),$(call check_or_remove_cached,$(package));)
+check-sources:
+	@$(foreach package,$(all_packages),$(call check_or_remove_sources,$(package));)
+
+$(host_prefix)/share/config.site: check-packages
+
+check-packages: check-sources
+
+install: check-packages $(host_prefix)/share/config.site
+
+
+download-one: check-sources $(all_sources)
+
+download-osx:
+	@$(MAKE) -s HOST=x86_64-apple-darwin11 download-one
+download-linux:
+	@$(MAKE) -s HOST=x86_64-unknown-linux-gnu download-one
+download-win:
+	@$(MAKE) -s HOST=x86_64-w64-mingw32 download-one
+download: download-osx download-linux download-win
+
+.PHONY: install cached download-one download-osx download-linux download-win download check-packages check-sources

--- a/depends/patches/boost/darwin_boost_atomic-1.patch
+++ b/depends/patches/boost/darwin_boost_atomic-1.patch
@@ -1,0 +1,35 @@
+diff --git a/include/boost/atomic/detail/cas128strong.hpp b/include/boost/atomic/detail/cas128strong.hpp
+index 906c13e..dcb4d7d 100644
+--- a/include/boost/atomic/detail/cas128strong.hpp
++++ b/include/boost/atomic/detail/cas128strong.hpp
+@@ -196,15 +196,17 @@ class base_atomic<T, void, 16, Sign>
+ 
+ public:
+     BOOST_DEFAULTED_FUNCTION(base_atomic(void), {})
+-    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT : v_(0)
++    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT
+     {
++        memset(&v_, 0, sizeof(v_));
+         memcpy(&v_, &v, sizeof(value_type));
+     }
+ 
+     void
+     store(value_type const& value, memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
+     {
+-        storage_type value_s = 0;
++        storage_type value_s;
++        memset(&value_s, 0, sizeof(value_s));
+         memcpy(&value_s, &value, sizeof(value_type));
+         platform_fence_before_store(order);
+         platform_store128(value_s, &v_);
+@@ -247,7 +249,9 @@ class base_atomic<T, void, 16, Sign>
+         memory_order success_order,
+         memory_order failure_order) volatile BOOST_NOEXCEPT
+     {
+-        storage_type expected_s = 0, desired_s = 0;
++        storage_type expected_s, desired_s;
++        memset(&expected_s, 0, sizeof(expected_s));
++        memset(&desired_s, 0, sizeof(desired_s));
+         memcpy(&expected_s, &expected, sizeof(value_type));
+         memcpy(&desired_s, &desired, sizeof(value_type));
+ 

--- a/depends/patches/boost/darwin_boost_atomic-2.patch
+++ b/depends/patches/boost/darwin_boost_atomic-2.patch
@@ -1,0 +1,55 @@
+diff --git a/include/boost/atomic/detail/gcc-atomic.hpp b/include/boost/atomic/detail/gcc-atomic.hpp
+index a130590..4af99a1 100644
+--- a/include/boost/atomic/detail/gcc-atomic.hpp
++++ b/include/boost/atomic/detail/gcc-atomic.hpp
+@@ -958,14 +958,16 @@ class base_atomic<T, void, 16, Sign>
+ 
+ public:
+     BOOST_DEFAULTED_FUNCTION(base_atomic(void), {})
+-    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT : v_(0)
++    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT
+     {
++        memset(&v_, 0, sizeof(v_));
+         memcpy(&v_, &v, sizeof(value_type));
+     }
+ 
+     void store(value_type const& v, memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
+     {
+-        storage_type tmp = 0;
++        storage_type tmp;
++        memset(&tmp, 0, sizeof(tmp));
+         memcpy(&tmp, &v, sizeof(value_type));
+         __atomic_store_n(&v_, tmp, atomics::detail::convert_memory_order_to_gcc(order));
+     }
+@@ -980,7 +982,8 @@ class base_atomic<T, void, 16, Sign>
+ 
+     value_type exchange(value_type const& v, memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
+     {
+-        storage_type tmp = 0;
++        storage_type tmp;
++        memset(&tmp, 0, sizeof(tmp));
+         memcpy(&tmp, &v, sizeof(value_type));
+         tmp = __atomic_exchange_n(&v_, tmp, atomics::detail::convert_memory_order_to_gcc(order));
+         value_type res;
+@@ -994,7 +997,9 @@ class base_atomic<T, void, 16, Sign>
+         memory_order success_order,
+         memory_order failure_order) volatile BOOST_NOEXCEPT
+     {
+-        storage_type expected_s = 0, desired_s = 0;
++        storage_type expected_s, desired_s;
++        memset(&expected_s, 0, sizeof(expected_s));
++        memset(&desired_s, 0, sizeof(desired_s));
+         memcpy(&expected_s, &expected, sizeof(value_type));
+         memcpy(&desired_s, &desired, sizeof(value_type));
+         const bool success = __atomic_compare_exchange_n(&v_, &expected_s, desired_s, false,
+@@ -1010,7 +1015,9 @@ class base_atomic<T, void, 16, Sign>
+         memory_order success_order,
+         memory_order failure_order) volatile BOOST_NOEXCEPT
+     {
+-        storage_type expected_s = 0, desired_s = 0;
++        storage_type expected_s, desired_s;
++        memset(&expected_s, 0, sizeof(expected_s));
++        memset(&desired_s, 0, sizeof(desired_s));
+         memcpy(&expected_s, &expected, sizeof(value_type));
+         memcpy(&desired_s, &desired, sizeof(value_type));
+         const bool success = __atomic_compare_exchange_n(&v_, &expected_s, desired_s, true,

--- a/depends/patches/boost/gcc_5_no_cxx11.patch
+++ b/depends/patches/boost/gcc_5_no_cxx11.patch
@@ -1,0 +1,37 @@
+From eec808554936ae068b23df07ab54d4dc6302a695 Mon Sep 17 00:00:00 2001
+From: jzmaddock <jzmaddock@gmail.com>
+Date: Sat, 23 Aug 2014 09:38:02 +0100
+Subject: [PATCH] Fix BOOST_NO_CXX11_VARIADIC_TEMPLATES definition - the
+ feature was introduced in GCC 4.4.
+
+---
+ include/boost/config/compiler/gcc.hpp | 9 +--------
+ 1 file changed, 1 insertion(+), 8 deletions(-)
+
+diff --git a/include/boost/config/compiler/gcc.hpp b/include/boost/config/compiler/gcc.hpp
+index f37159d..97d8a18 100644
+--- a/include/boost/config/compiler/gcc.hpp
++++ b/include/boost/config/compiler/gcc.hpp
+@@ -154,14 +154,6 @@
+ #  define BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS
+ #  define BOOST_NO_CXX11_RVALUE_REFERENCES
+ #  define BOOST_NO_CXX11_STATIC_ASSERT
+-
+-// Variadic templates compiler:
+-//   http://www.generic-programming.org/~dgregor/cpp/variadic-templates.html
+-#  if defined(__VARIADIC_TEMPLATES) || (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4) && defined(__GXX_EXPERIMENTAL_CXX0X__))
+-#    define BOOST_HAS_VARIADIC_TMPL
+-#  else
+-#    define BOOST_NO_CXX11_VARIADIC_TEMPLATES
+-#  endif
+ #endif
+ 
+ // C++0x features in 4.4.n and later
+@@ -176,6 +168,7 @@
+ #  define BOOST_NO_CXX11_DELETED_FUNCTIONS
+ #  define BOOST_NO_CXX11_TRAILING_RESULT_TYPES
+ #  define BOOST_NO_CXX11_INLINE_NAMESPACES
++#  define BOOST_NO_CXX11_VARIADIC_TEMPLATES
+ #endif
+ 
+ #if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 5)

--- a/depends/patches/native_cdrkit/cdrkit-deterministic.patch
+++ b/depends/patches/native_cdrkit/cdrkit-deterministic.patch
@@ -1,0 +1,86 @@
+--- cdrkit-1.1.11.old/genisoimage/tree.c	2008-10-21 19:57:47.000000000 -0400
++++ cdrkit-1.1.11/genisoimage/tree.c	2013-12-06 00:23:18.489622668 -0500
+@@ -1139,8 +1139,9 @@
+ scan_directory_tree(struct directory *this_dir, char *path, 
+ 						  struct directory_entry *de)
+ {
+-	DIR		*current_dir;
++        int             current_file;
+ 	char		whole_path[PATH_MAX];
++        struct dirent  **d_list;
+ 	struct dirent	*d_entry;
+ 	struct directory *parent;
+ 	int		dflag;
+@@ -1164,7 +1165,8 @@
+ 	this_dir->dir_flags |= DIR_WAS_SCANNED;
+ 
+ 	errno = 0;	/* Paranoia */
+-	current_dir = opendir(path);
++	//current_dir = opendir(path);
++        current_file = scandir(path, &d_list, NULL, alphasort);
+ 	d_entry = NULL;
+ 
+ 	/*
+@@ -1173,12 +1175,12 @@
+ 	 */
+ 	old_path = path;
+ 
+-	if (current_dir) {
++	if (current_file >= 0) {
+ 		errno = 0;
+-		d_entry = readdir(current_dir);
++		d_entry = d_list[0];
+ 	}
+ 
+-	if (!current_dir || !d_entry) {
++	if (current_file < 0 || !d_entry) {
+ 		int	ret = 1;
+ 
+ #ifdef	USE_LIBSCHILY
+@@ -1191,8 +1193,8 @@
+ 			de->isorec.flags[0] &= ~ISO_DIRECTORY;
+ 			ret = 0;
+ 		}
+-		if (current_dir)
+-			closedir(current_dir);
++		if(d_list)
++			free(d_list);
+ 		return (ret);
+ 	}
+ #ifdef	ABORT_DEEP_ISO_ONLY
+@@ -1208,7 +1210,7 @@
+ 			errmsgno(EX_BAD, "use Rock Ridge extensions via -R or -r,\n");
+ 			errmsgno(EX_BAD, "or allow deep ISO9660 directory nesting via -D.\n");
+ 		}
+-		closedir(current_dir);
++		free(d_list);
+ 		return (1);
+ 	}
+ #endif
+@@ -1250,13 +1252,13 @@
+ 		 * The first time through, skip this, since we already asked
+ 		 * for the first entry when we opened the directory.
+ 		 */
+-		if (dflag)
+-			d_entry = readdir(current_dir);
++		if (dflag && current_file >= 0)
++			d_entry = d_list[current_file];
+ 		dflag++;
+ 
+-		if (!d_entry)
++		if (current_file < 0)
+ 			break;
+-
++                current_file--;
+ 		/* OK, got a valid entry */
+ 
+ 		/* If we do not want all files, then pitch the backups. */
+@@ -1348,7 +1350,7 @@
+ 		insert_file_entry(this_dir, whole_path, d_entry->d_name);
+ #endif	/* APPLE_HYB */
+ 	}
+-	closedir(current_dir);
++	free(d_list);
+ 
+ #ifdef APPLE_HYB
+ 	/*

--- a/depends/patches/qt/fix-xcb-include-order.patch
+++ b/depends/patches/qt/fix-xcb-include-order.patch
@@ -1,0 +1,45 @@
+--- old/qtbase/src/plugins/platforms/xcb/xcb_qpa_lib.pro 2015-03-17 02:06:42.705930685 +0000
++++ new/qtbase/src/plugins/platforms/xcb/xcb_qpa_lib.pro 2015-03-17 02:08:41.281926351 +0000
+@@ -94,8 +94,6 @@
+
+ DEFINES += $$QMAKE_DEFINES_XCB
+ LIBS += $$QMAKE_LIBS_XCB
+-QMAKE_CXXFLAGS += $$QMAKE_CFLAGS_XCB
+-QMAKE_CFLAGS += $$QMAKE_CFLAGS_XCB
+
+ CONFIG += qpa/genericunixfontdatabase
+
+@@ -104,7 +102,8 @@
+ contains(QT_CONFIG, xcb-qt) {
+     DEFINES += XCB_USE_RENDER
+     XCB_DIR = ../../../3rdparty/xcb
+-    INCLUDEPATH += $$XCB_DIR/include $$XCB_DIR/sysinclude
++    QMAKE_CFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/sysinclude $$QMAKE_CFLAGS_XCB
++    QMAKE_CXXFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/sysinclude $$QMAKE_CFLAGS_XCB
+     LIBS += -lxcb -L$$OUT_PWD/xcb-static -lxcb-static
+ } else {
+     LIBS += -lxcb -lxcb-image -lxcb-icccm -lxcb-sync -lxcb-xfixes -lxcb-shm -lxcb-randr -lxcb-shape -lxcb-keysyms
+--- old/qtbase/src/plugins/platforms/xcb/xcb-static/xcb-static.pro      2015-03-17 02:07:04.641929383 +0000
++++ new/qtbase/src/plugins/platforms/xcb/xcb-static/xcb-static.pro      2015-03-17 02:10:15.485922059 +0000
+@@ -8,7 +8,8 @@
+
+ XCB_DIR = ../../../../3rdparty/xcb
+
+-INCLUDEPATH += $$XCB_DIR/include $$XCB_DIR/include/xcb $$XCB_DIR/sysinclude
++QMAKE_CFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/include/xcb -I$$XCB_DIR/sysinclude
++QMAKE_CXXFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/include/xcb -I$$XCB_DIR/sysinclude
+
+ QMAKE_CXXFLAGS += $$QMAKE_CFLAGS_XCB
+ QMAKE_CFLAGS += $$QMAKE_CFLAGS_XCB
+--- old/qtbase/src/plugins/platforms/xcb/xcb-plugin.pro	2015-07-24 16:02:59.530038830 -0400
++++ new/qtbase/src/plugins/platforms/xcb/xcb-plugin.pro	2015-07-24 16:01:22.106037459 -0400
+@@ -11,3 +11,9 @@
+     qxcbmain.cpp
+ OTHER_FILES += xcb.json README
+
++contains(QT_CONFIG, xcb-qt) {
++    DEFINES += XCB_USE_RENDER
++    XCB_DIR = ../../../3rdparty/xcb
++    QMAKE_CFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/sysinclude $$QMAKE_CFLAGS_XCB
++    QMAKE_CXXFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/sysinclude $$QMAKE_CFLAGS_XCB
++}

--- a/depends/patches/qt/mingw-uuidof.patch
+++ b/depends/patches/qt/mingw-uuidof.patch
@@ -1,0 +1,44 @@
+--- old/qtbase/src/plugins/platforms/windows/qwindowscontext.cpp	2015-06-20 17:40:20.956781548 -0400
++++ new/qtbase/src/plugins/platforms/windows/qwindowscontext.cpp	2015-06-20 17:29:32.052772416 -0400
+@@ -69,7 +69,7 @@
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <windowsx.h>
+-#ifndef Q_OS_WINCE
++#if !defined(Q_OS_WINCE) && (!defined(USE___UUIDOF) || (defined(USE___UUIDOF) && USE___UUIDOF == 1))
+ #  include <comdef.h>
+ #endif
+ 
+@@ -762,7 +762,7 @@
+                           HWND_MESSAGE, NULL, (HINSTANCE)GetModuleHandle(0), NULL);
+ }
+ 
+-#ifndef Q_OS_WINCE
++#if !defined(Q_OS_WINCE) && (!defined(USE___UUIDOF) || (defined(USE___UUIDOF) && USE___UUIDOF == 1))
+ // Re-engineered from the inline function _com_error::ErrorMessage().
+ // We cannot use it directly since it uses swprintf_s(), which is not
+ // present in the MSVCRT.DLL found on Windows XP (QTBUG-35617).
+@@ -781,7 +781,7 @@
+          return QStringLiteral("IDispatch error #") + QString::number(wCode);
+      return QStringLiteral("Unknown error 0x0") + QString::number(comError.Error(), 16);
+ }
+-#endif // !Q_OS_WINCE
++#endif // !defined(Q_OS_WINCE) && (!defined(USE___UUIDOF) || (defined(USE___UUIDOF) && USE___UUIDOF == 1))
+ 
+ /*!
+     \brief Common COM error strings.
+@@ -846,12 +846,12 @@
+     default:
+         break;
+     }
+-#ifndef Q_OS_WINCE
++#if !defined(Q_OS_WINCE) && (!defined(USE___UUIDOF) || (defined(USE___UUIDOF) && USE___UUIDOF == 1))
+     _com_error error(hr);
+     result += QByteArrayLiteral(" (");
+     result += errorMessageFromComError(error);
+     result += ')';
+-#endif // !Q_OS_WINCE
++#endif // !defined(Q_OS_WINCE) && (!defined(USE___UUIDOF) || (defined(USE___UUIDOF) && USE___UUIDOF == 1))
+     return result;
+ }
+ 

--- a/depends/patches/qt/pidlist_absolute.patch
+++ b/depends/patches/qt/pidlist_absolute.patch
@@ -1,0 +1,37 @@
+diff -dur old/qtbase/src/plugins/platforms/windows/qwindowscontext.h new/qtbase/src/plugins/platforms/windows/qwindowscontext.h
+--- old/qtbase/src/plugins/platforms/windows/qwindowscontext.h	2015-06-29 22:04:40.000000000 +0200
++++ new/qtbase/src/plugins/platforms/windows/qwindowscontext.h	2015-11-01 12:55:59.751234846 +0100
+@@ -124,10 +124,18 @@
+     inline void init();
+ 
+     typedef HRESULT (WINAPI *SHCreateItemFromParsingName)(PCWSTR, IBindCtx *, const GUID&, void **);
++#if defined(Q_CC_MINGW) && (!defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 3)
++    typedef HRESULT (WINAPI *SHGetKnownFolderIDList)(const GUID &, DWORD, HANDLE, ITEMIDLIST **);
++#else
+     typedef HRESULT (WINAPI *SHGetKnownFolderIDList)(const GUID &, DWORD, HANDLE, PIDLIST_ABSOLUTE *);
++#endif
+     typedef HRESULT (WINAPI *SHGetStockIconInfo)(int , int , _SHSTOCKICONINFO *);
+     typedef HRESULT (WINAPI *SHGetImageList)(int, REFIID , void **);
++#if defined(Q_CC_MINGW) && (!defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 3)
++    typedef HRESULT (WINAPI *SHCreateItemFromIDList)(const ITEMIDLIST *, REFIID, void **);
++#else
+     typedef HRESULT (WINAPI *SHCreateItemFromIDList)(PCIDLIST_ABSOLUTE, REFIID, void **);
++#endif
+ 
+     SHCreateItemFromParsingName sHCreateItemFromParsingName;
+     SHGetKnownFolderIDList sHGetKnownFolderIDList;
+diff -dur old/qtbase/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp new/qtbase/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp
+--- old/qtbase/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp	2015-06-29 22:04:40.000000000 +0200
++++ new/qtbase/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp	2015-11-01 13:41:09.503149772 +0100
+@@ -1008,7 +1008,11 @@
+             qWarning() << __FUNCTION__ << ": Invalid CLSID: " << url.path();
+             return Q_NULLPTR;
+         }
++#if defined(Q_CC_MINGW) && (!defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 3)
++        ITEMIDLIST *idList;
++#else
+         PIDLIST_ABSOLUTE idList;
++#endif
+         HRESULT hr = QWindowsContext::shell32dll.sHGetKnownFolderIDList(uuid, 0, 0, &idList);
+         if (FAILED(hr)) {
+             qErrnoWarning("%s: SHGetKnownFolderIDList(%s)) failed", __FUNCTION__, qPrintable(url.toString()));

--- a/depends/patches/qt46/stlfix.patch
+++ b/depends/patches/qt46/stlfix.patch
@@ -1,0 +1,10 @@
+--- old/config.tests/unix/stl/stltest.cpp	2011-06-23 03:45:23.000000000 -0400
++++ new/config.tests/unix/stl/stltest.cpp	2014-08-28 00:54:04.154837604 -0400
+@@ -49,6 +49,7 @@
+ #include <vector>
+ #include <algorithm>
+ #include <iostream>
++#include <cstddef>
+ 
+ // something mean to see if the compiler and C++ standard lib are good enough
+ template<class K, class T>


### PR DESCRIPTION
Recover lost files required for cross-compilation wallet. 

Required files imported from Dash code from v0.12.2.x branch.
Most of the files and directory structure in the folder idapay-refresh/depends are identical with the structure folder dash/depends of Dash files in v0.12.2.x branch.

Only in depends-dash/: Makefile
Only in depends-dash/patches: boost
Only in depends-dash/patches: native_cdrkit
Only in depends-dash/patches/qt: fix-xcb-include-order.patch
Only in depends-dash/patches/qt: mingw-uuidof.patch
Only in depends-dash/patches/qt: pidlist_absolute.patch
Only in depends-dash/patches: qt46
Files depends-idapay-refresh/README.md and depends-dash/README.md differ

More info:
https://pastebin.com/QYyZpApS